### PR TITLE
Feature update llvm to 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,14 +50,19 @@ list(APPEND CMAKE_PREFIX_PATH "${CT_Clang_INSTALL_DIR}/lib/cmake/clang/")
 
 find_package(Clang REQUIRED CONFIG)
 
-# Sanity check. As Clang does not expose e.g. `CLANG_VERSION_MAJOR` through
-# AddClang.cmake, we have to use LLVM_VERSION_MAJOR instead.
-# TODO: Revisit when next version is released.
-if(NOT "12" VERSION_EQUAL "${LLVM_VERSION_MAJOR}")
-  message(FATAL_ERROR "Found LLVM ${LLVM_VERSION_MAJOR}, but need LLVM 12")
+
+if (LLVM_VERSION_MAJOR LESS 12)
+  message(WARNING "Found LLVM ${LLVM_VERSION_MAJOR}, but LLVM 12 or newer is required.")
+  add_definitions(-DGRAYC_OLD_LLVM_API)
+
+elseif (LLVM_VERSION_MAJOR GREATER 17)
+  message(WARNING "Found LLVM ${LLVM_VERSION_MAJOR}, but this project targets LLVM 17. Proceeding may cause issues.")
+
+elseif (NOT LLVM_VERSION_MAJOR EQUAL 12 AND NOT LLVM_VERSION_MAJOR EQUAL 17)
+  message(WARNING "Found LLVM ${LLVM_VERSION_MAJOR}, but this project officially supports LLVM 12 and LLVM 17 only. Proceeding may cause issues.")
 endif()
 
-message(STATUS "Found Clang ${LLVM_PACKAGE_VERSION}")
+
 message(STATUS "Using ClangConfig.cmake in: ${CT_Clang_INSTALL_DIR}")
 
 message("CLANG STATUS:

--- a/README.md
+++ b/README.md
@@ -18,10 +18,8 @@ This is the revamped version of the one presented in our ISSTA '23 paper. It con
 ## Installation
 
 ```
-wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-sudo apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-12 main"
 sudo apt-get update
-sudo apt-get install -y llvm-12 llvm-12-dev llvm-12-tools clang-12 libclang-common-12-dev libclang-12-dev 
+sudo apt-get install -y llvm-17 llvm-17-dev llvm-17-tools clang-17 libclang-common-17-dev libclang-17-dev 
 
 This builds both LLVM and Clang on Ubuntu
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ git clone https://github.com/srg-imperial/GrayC.git
 cd GrayC
 mkdir build
 cd build
-cmake -GNinja -DCMAKE_C_COMPILER=clang-12 -DCMAKE_CXX_COMPILER=clang++-12 -DLLVM_CONFIG_BINARY=llvm-config-12 ../
+cmake -GNinja -DCMAKE_C_COMPILER=clang-17 -DCMAKE_CXX_COMPILER=clang++-17 -DLLVM_CONFIG_BINARY=llvm-config-17 ../
 ninja
 ```
 

--- a/clang-diff/CMakeLists.txt
+++ b/clang-diff/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.13.4)
 project(GrayC)
 
 #===============================================================================

--- a/grayc/CMakeLists.txt
+++ b/grayc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.13.4)
 project(grayc-cd)
 
 #===============================================================================

--- a/grayc/Compatability.h
+++ b/grayc/Compatability.h
@@ -1,0 +1,29 @@
+// Compatability layer for different LLVM versions (12 vs 17)
+
+#pragma once
+
+#ifdef GRAYC_OLD_LLVM_API
+// Optional
+#include "llvm/ADT/Optional.h"
+#define OPTIONAL( T ) llvm::Optional<T>
+#define HAS_VALUE( opt ) ( opt.hasValue() )
+#define OPTIONAL_NONE llvm::None
+#define GET_VALUE( opt ) ( opt.getValue() )
+#define GET_VALUE_OR( opt, default ) ( opt.getValueOr( default ) )
+
+// StringRef
+#define EQUALS_INSENSITIVE( str1, str2 ) ( str1.equals_lower( str2 ) )
+
+#else
+// Optional
+#include <optional>
+#define OPTIONAL( T ) std::optional<T>
+#define HAS_VALUE( opt ) ( opt.has_value() )
+#define OPTIONAL_NONE std::nullopt
+#define GET_VALUE( opt ) ( *opt )
+#define GET_VALUE_OR( opt, default ) ( opt.value_or( default ) )
+#include "llvm/Support/WithColor.h"
+
+// StringRef
+#define EQUALS_INSENSITIVE( str1, str2 ) ( str1.equals_insensitive( str2 ) )
+#endif

--- a/grayc/GrayC.cpp
+++ b/grayc/GrayC.cpp
@@ -197,7 +197,11 @@ private:
     if (FilePath.empty())
       return SourceLocation();
 
+    #ifdef GRAYC_OLD_LLVM_API
     auto File = SourceMgr.getFileManager().getFile(FilePath);
+    #else
+    auto File = SourceMgr.getFileManager().getFileRef(FilePath);
+    #endif
     if (!File)
       return SourceLocation();
 

--- a/grayc/GrayC.cpp
+++ b/grayc/GrayC.cpp
@@ -14,20 +14,16 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "Compatability.h"
 #include "GrayC.h"
 #include "GrayCCheck.h"
 #include "GrayCDiagnosticConsumer.h"
 #include "GrayCModuleRegistry.h"
 #include "GrayCProfiling.h"
 #include "clang/AST/ASTConsumer.h"
-#include "clang/AST/ASTContext.h"
-#include "clang/AST/Decl.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
-#include "clang/Config/config.h"
 #include "clang/Format/Format.h"
-#include "clang/Frontend/ASTConsumers.h"
 #include "clang/Frontend/CompilerInstance.h"
-#include "clang/Frontend/FrontendActions.h"
 #include "clang/Frontend/FrontendDiagnostic.h"
 #include "clang/Frontend/MultiplexConsumer.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"
@@ -38,11 +34,8 @@
 #include "clang/Rewrite/Frontend/FrontendActions.h"
 #include "clang/Tooling/Core/Diagnostic.h"
 #include "clang/Tooling/DiagnosticsYaml.h"
-#include "clang/Tooling/Refactoring.h"
-#include "clang/Tooling/ReplacementsYaml.h"
 #include "clang/Tooling/Tooling.h"
 #include "llvm/Support/Process.h"
-#include "llvm/Support/Signals.h"
 #include <algorithm>
 #include <utility>
 
@@ -69,7 +62,7 @@ public:
               DiagPrinter),
         SourceMgr(Diags, Files), Context(Context), ApplyFixes(ApplyFixes),
         TotalFixes(0), AppliedFixes(0), WarningsAsErrors(0) {
-    DiagOpts->ShowColors = Context.getOptions().UseColor.getValueOr(
+    DiagOpts->ShowColors = GET_VALUE_OR(Context.getOptions().UseColor,
         llvm::sys::Process::StandardOutHasColors());
     DiagPrinter->BeginSourceFile(LangOpts);
   }

--- a/grayc/GrayCCheck.cpp
+++ b/grayc/GrayCCheck.cpp
@@ -183,11 +183,11 @@ GrayCCheck::OptionsView::getEnumInt(StringRef LocalName,
   unsigned EditDistance = -1;
   for (const auto &NameAndEnum : Mapping) {
     if (IgnoreCase) {
-      if (Value.equals_lower(NameAndEnum.second))
+      if (EQUALS_INSENSITIVE(Value, NameAndEnum.second))
         return NameAndEnum.first;
     } else if (Value.equals(NameAndEnum.second)) {
       return NameAndEnum.first;
-    } else if (Value.equals_lower(NameAndEnum.second)) {
+    } else if (EQUALS_INSENSITIVE(Value, NameAndEnum.second)) {
       Closest = NameAndEnum.second;
       EditDistance = 0;
       continue;

--- a/grayc/GrayCCheck.h
+++ b/grayc/GrayCCheck.h
@@ -9,11 +9,12 @@
 #ifndef GRAYC_GrayCCheck_H
 #define GRAYC_GrayCCheck_H
 
+#include "Compatability.h"
+
 #include "GrayCDiagnosticConsumer.h"
 #include "GrayCOptions.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/Basic/Diagnostic.h"
-#include "llvm/ADT/Optional.h"
 #include "llvm/Support/Error.h"
 #include <type_traits>
 #include <utility>
@@ -71,7 +72,7 @@ public:
 private:
   const std::string LookupName;
   const std::string LookupValue;
-  const llvm::Optional<std::string> SuggestedValue;
+  const OPTIONAL(std::string) SuggestedValue;
 };
 
 class UnparseableIntegerOptionError

--- a/grayc/GrayCDiagnosticConsumer.cpp
+++ b/grayc/GrayCDiagnosticConsumer.cpp
@@ -69,9 +69,9 @@ protected:
     }
     assert(Error.Message.Message.empty() && "Overwriting a diagnostic message");
     Error.Message = TidyMessage;
-    for (const CharSourceRange &SourceRange : Ranges) {
-      Error.Ranges.emplace_back(Loc.getManager(), SourceRange);
-    }
+    // for (const CharSourceRange &SourceRange : Ranges) {
+    //   Error.Ranges.emplace_back(Loc.getManager(), SourceRange);
+    // }
   }
 
   void emitDiagnosticLoc(FullSourceLoc Loc, PresumedLoc PLoc,
@@ -214,10 +214,10 @@ void GrayCContext::setProfileStoragePrefix(StringRef Prefix) {
   ProfilePrefix = std::string(Prefix);
 }
 
-llvm::Optional<GrayCProfiling::StorageParams>
+OPTIONAL(GrayCProfiling::StorageParams)
 GrayCContext::getProfileStorageParams() const {
   if (ProfilePrefix.empty())
-    return llvm::None;
+    return OPTIONAL_NONE;
 
   return GrayCProfiling::StorageParams(ProfilePrefix, CurrentFile);
 }
@@ -302,7 +302,7 @@ static bool IsNOLINTFound(StringRef NolintDirectiveText, StringRef Line,
   return true;
 }
 
-static llvm::Optional<StringRef> getBuffer(const SourceManager &SM, FileID File,
+static OPTIONAL(StringRef) getBuffer(const SourceManager &SM, FileID File,
                                            bool AllowIO) {
   // This is similar to the implementation of SourceManager::getBufferData(),
   // but uses ContentCache::getRawBuffer() rather than getBuffer() if
@@ -320,7 +320,7 @@ static llvm::Optional<StringRef> getBuffer(const SourceManager &SM, FileID File,
   // // if (!Buffer || CharDataInvalid)
   // //   return llvm::None;
   // // return Buffer.getBuffer();
-  return llvm::None;
+  return OPTIONAL_NONE;
 }
 
 static bool LineIsMarkedWithNOLINT(const SourceManager &SM, SourceLocation Loc,
@@ -330,7 +330,7 @@ static bool LineIsMarkedWithNOLINT(const SourceManager &SM, SourceLocation Loc,
   FileID File;
   unsigned Offset;
   std::tie(File, Offset) = SM.getDecomposedSpellingLoc(Loc);
-  llvm::Optional<StringRef> Buffer = getBuffer(SM, File, AllowIO);
+  OPTIONAL(StringRef) Buffer = getBuffer(SM, File, AllowIO);
   if (!Buffer)
     return false;
 

--- a/grayc/GrayCDiagnosticConsumer.h
+++ b/grayc/GrayCDiagnosticConsumer.h
@@ -9,6 +9,7 @@
 #ifndef GRAYC_GrayCDiagnosticConsumer_H
 #define GRAYC_GrayCDiagnosticConsumer_H
 
+#include "Compatability.h"
 #include "GrayCOptions.h"
 #include "GrayCProfiling.h"
 #include "clang/Basic/Diagnostic.h"
@@ -148,7 +149,7 @@ public:
 
   /// Control storage of profile date.
   void setProfileStoragePrefix(StringRef ProfilePrefix);
-  llvm::Optional<GrayCProfiling::StorageParams>
+  OPTIONAL(GrayCProfiling::StorageParams)
   getProfileStorageParams() const;
 
   /// Should be called when starting to process new translation unit.

--- a/grayc/GrayCOptions.cpp
+++ b/grayc/GrayCOptions.cpp
@@ -115,7 +115,7 @@ GrayCOptions GrayCOptions::getDefaults() {
   Options.SystemHeaders = false;
   Options.FormatStyle = "none";
   Options.Seed = 1234567;
-  Options.User = llvm::None;
+  Options.User = OPTIONAL_NONE;
   unsigned Priority = 0;
   for (const GrayCModuleRegistry::entry &Module :
        GrayCModuleRegistry::entries())
@@ -125,7 +125,7 @@ GrayCOptions GrayCOptions::getDefaults() {
 }
 
 template <typename T>
-static void mergeVectors(Optional<T> &Dest, const Optional<T> &Src) {
+static void mergeVectors(OPTIONAL(T) &Dest, const OPTIONAL(T) &Src) {
   if (Src) {
     if (Dest)
       Dest->insert(Dest->end(), Src->begin(), Src->end());
@@ -134,14 +134,14 @@ static void mergeVectors(Optional<T> &Dest, const Optional<T> &Src) {
   }
 }
 
-static void mergeCommaSeparatedLists(Optional<std::string> &Dest,
-                                     const Optional<std::string> &Src) {
+static void mergeCommaSeparatedLists(OPTIONAL(std::string) &Dest,
+                                     const OPTIONAL(std::string) &Src) {
   if (Src)
     Dest = (Dest && !Dest->empty() ? *Dest + "," : "") + *Src;
 }
 
 template <typename T>
-static void overrideValue(Optional<T> &Dest, const Optional<T> &Src) {
+static void overrideValue(OPTIONAL(T) &Dest, const OPTIONAL(T) &Src) {
   if (Src)
     Dest = Src;
 }
@@ -207,7 +207,7 @@ std::vector<OptionsSource>
 ConfigOptionsProvider::getRawOptions(llvm::StringRef FileName) {
   std::vector<OptionsSource> RawOptions =
       DefaultOptionsProvider::getRawOptions(FileName);
-  if (ConfigOptions.InheritParentConfig.getValueOr(false)) {
+  if (GET_VALUE_OR(ConfigOptions.InheritParentConfig, false)) {
     LLVM_DEBUG(llvm::dbgs()
                << "Getting options for file " << FileName << "...\n");
     assert(FS && "FS must be set.");
@@ -254,7 +254,7 @@ void FileOptionsBaseProvider::addRawFileOptions(
   StringRef Path = llvm::sys::path::parent_path(AbsolutePath);
   for (StringRef CurrentPath = Path; !CurrentPath.empty();
        CurrentPath = llvm::sys::path::parent_path(CurrentPath)) {
-    llvm::Optional<OptionsSource> Result;
+    OPTIONAL(OptionsSource) Result;
 
     auto Iter = CachedOptions.find(CurrentPath);
     if (Iter != CachedOptions.end())
@@ -275,7 +275,7 @@ void FileOptionsBaseProvider::addRawFileOptions(
       CachedOptions[Path] = *Result;
 
       CurOptions.push_back(*Result);
-      if (!Result->first.InheritParentConfig.getValueOr(false))
+      if (!GET_VALUE_OR(Result->first.InheritParentConfig, false))
         break;
     }
   }
@@ -324,14 +324,14 @@ FileOptionsProvider::getRawOptions(StringRef FileName) {
   return RawOptions;
 }
 
-llvm::Optional<OptionsSource>
+OPTIONAL(OptionsSource)
 FileOptionsBaseProvider::tryReadConfigFile(StringRef Directory) {
   assert(!Directory.empty());
 
   if (!llvm::sys::fs::is_directory(Directory)) {
     llvm::errs() << "Error reading configuration from " << Directory
                  << ": directory doesn't exist.\n";
-    return llvm::None;
+    return OPTIONAL_NONE;
   }
 
   for (const ConfigFileHandler &ConfigHandler : ConfigHandlers) {
@@ -368,7 +368,7 @@ FileOptionsBaseProvider::tryReadConfigFile(StringRef Directory) {
     }
     return OptionsSource(*ParsedOptions, ConfigFile.c_str());
   }
-  return llvm::None;
+  return OPTIONAL_NONE;
 }
 
 /// Parses -line-filter option and stores it to the \c Options.

--- a/grayc/GrayCOptions.h
+++ b/grayc/GrayCOptions.h
@@ -9,8 +9,8 @@
 #ifndef GRAYC_GrayCOptions_H
 #define GRAYC_GrayCOptions_H
 
+#include "Compatability.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
-#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/ErrorOr.h"
@@ -63,17 +63,17 @@ struct GrayCOptions {
                              unsigned Order) const;
 
   /// Checks filter.
-  llvm::Optional<std::string> Checks;
+  OPTIONAL(std::string) Checks;
 
   /// WarningsAsErrors filter.
-  llvm::Optional<std::string> WarningsAsErrors;
+  OPTIONAL(std::string) WarningsAsErrors;
 
   /// Output warnings from headers matching this filter. Warnings from
   /// main files will always be displayed.
-  llvm::Optional<std::string> HeaderFilterRegex;
+  OPTIONAL(std::string) HeaderFilterRegex;
 
   /// Output warnings from system headers matching \c HeaderFilterRegex.
-  llvm::Optional<bool> SystemHeaders;
+  OPTIONAL(bool) SystemHeaders;
 
   /// Format code around applied fixes with clang-format using this
   /// style.
@@ -87,16 +87,16 @@ struct GrayCOptions {
   ///   * '{inline-formatting-style-in-yaml-format}'.
   ///
   /// See clang-format documentation for more about configuring format style.
-  llvm::Optional<std::string> FormatStyle;
+  OPTIONAL(std::string) FormatStyle;
 
   /// Specifies the name or e-mail of the user running grayc.
   ///
   /// This option is used, for example, to place the correct user name in TODO()
   /// comments in the relevant check.
-  llvm::Optional<std::string> User;
+  OPTIONAL(std::string) User;
 
   // Specifies the seed to be used during mutations
-  llvm::Optional<long> Seed;
+  OPTIONAL(long) Seed;
   
   /// Helper structure for storing option value with priority of the value.
   struct GrayCValue {
@@ -119,10 +119,10 @@ struct GrayCOptions {
   typedef std::vector<std::string> ArgList;
 
   /// Add extra compilation arguments to the end of the list.
-  llvm::Optional<ArgList> ExtraArgs;
+  OPTIONAL(ArgList) ExtraArgs;
 
   /// Add extra compilation arguments to the start of the list.
-  llvm::Optional<ArgList> ExtraArgsBefore;
+  OPTIONAL(ArgList) ExtraArgsBefore;
 
   /// Only used in the FileOptionsProvider and ConfigOptionsProvider. If true
   /// and using a FileOptionsProvider, it will take a configuration file in the
@@ -131,10 +131,10 @@ struct GrayCOptions {
   /// config on top of any configuation file it finds in the directory using the
   /// same logic as FileOptionsProvider. If false or missing, only this
   /// configuration file will be used.
-  llvm::Optional<bool> InheritParentConfig;
+  OPTIONAL(bool) InheritParentConfig;
 
   /// Use colors in diagnostics. If missing, it will be auto detected.
-  llvm::Optional<bool> UseColor;
+  OPTIONAL(bool) UseColor;
 };
 
 /// Abstract interface for retrieving various GrayC options.
@@ -230,7 +230,7 @@ protected:
 
   /// Try to read configuration files from \p Directory using registered
   /// \c ConfigHandlers.
-  llvm::Optional<OptionsSource> tryReadConfigFile(llvm::StringRef Directory);
+  OPTIONAL(OptionsSource) tryReadConfigFile(llvm::StringRef Directory);
 
   llvm::StringMap<OptionsSource> CachedOptions;
   GrayCOptions OverrideOptions;

--- a/grayc/GrayCProfiling.cpp
+++ b/grayc/GrayCProfiling.cpp
@@ -55,7 +55,7 @@ void GrayCProfiling::printAsJSON(llvm::raw_ostream &OS) {
 }
 
 void GrayCProfiling::storeProfileData() {
-  assert(Storage.hasValue() && "We should have a filename.");
+  assert(HAS_VALUE(Storage) && "We should have a filename.");
 
   llvm::SmallString<256> OutputDirectory(Storage->StoreFilename);
   llvm::sys::path::remove_filename(OutputDirectory);
@@ -76,13 +76,13 @@ void GrayCProfiling::storeProfileData() {
   printAsJSON(OS);
 }
 
-GrayCProfiling::GrayCProfiling(llvm::Optional<StorageParams> Storage)
+GrayCProfiling::GrayCProfiling(OPTIONAL(StorageParams) Storage)
     : Storage(std::move(Storage)) {}
 
 GrayCProfiling::~GrayCProfiling() {
   TG.emplace("grayc", "GrayC checks profiling", Records);
 
-  if (!Storage.hasValue())
+  if (!HAS_VALUE(Storage))
     printUserFriendlyTable(llvm::errs());
   else
     storeProfileData();

--- a/grayc/GrayCProfiling.h
+++ b/grayc/GrayCProfiling.h
@@ -9,7 +9,8 @@
 #ifndef GRAYC_GrayCProfiling_H
 #define GRAYC_GrayCProfiling_H
 
-#include "llvm/ADT/Optional.h"
+#include "Compatability.h"
+
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/Chrono.h"
 #include "llvm/Support/Timer.h"
@@ -35,9 +36,8 @@ public:
   };
 
 private:
-  llvm::Optional<llvm::TimerGroup> TG;
-
-  llvm::Optional<StorageParams> Storage;
+  OPTIONAL(llvm::TimerGroup) TG;
+  OPTIONAL(StorageParams) Storage;
 
   void printUserFriendlyTable(llvm::raw_ostream &OS);
   void printAsJSON(llvm::raw_ostream &OS);
@@ -49,7 +49,7 @@ public:
 
   GrayCProfiling() = default;
 
-  GrayCProfiling(llvm::Optional<StorageParams> Storage);
+  GrayCProfiling(OPTIONAL(StorageParams) Storage);
 
   ~GrayCProfiling();
 };

--- a/grayc/cmutation/AssignmentExpressionMutator.cpp
+++ b/grayc/cmutation/AssignmentExpressionMutator.cpp
@@ -46,9 +46,9 @@ namespace clang
           const MatchFinder::MatchResult &Result, const BinaryOperator *B,
           SourceLocation InitialLoc, SourceLocation EndLocHint)
       {
-        GrayCRandomManager::CreateInstance(Seed.getValue(), 65000);
+        GrayCRandomManager::CreateInstance(GET_VALUE(Seed), 65000);
         if (!InitialLoc.isValid()){
-          GrayCRandomManager::DeleteInstance(Seed.getValue());
+          GrayCRandomManager::DeleteInstance(GET_VALUE(Seed));
           return false;
         }
         const SourceManager &SM = *Result.SourceManager;
@@ -59,7 +59,7 @@ namespace clang
             CharSourceRange::getTokenRange(B->getSourceRange()), SM,
             Context->getLangOpts());
         if (FileRange.isInvalid()){
-          GrayCRandomManager::DeleteInstance(Seed.getValue());
+          GrayCRandomManager::DeleteInstance(GET_VALUE(Seed));
           return false;
         }
         InitialLoc = Lexer::makeFileCharRange(
@@ -68,7 +68,7 @@ namespace clang
                          .getBegin();
 
         if (InitialLoc.isInvalid()){
-          GrayCRandomManager::DeleteInstance(Seed.getValue());
+          GrayCRandomManager::DeleteInstance(GET_VALUE(Seed));
           return false;
         }
         InitialLoc = B->getRHS()->getBeginLoc();
@@ -99,14 +99,14 @@ namespace clang
         llvm::WithColor::remark() << "Expression built : " << MutatedAssignment.str() << "\n";
 
         Diag << FixItHint::CreateReplacement(CharSourceRange::getTokenRange(InitialLoc, EndLocHint), MutatedAssignment.str());
-        GrayCRandomManager::DeleteInstance(Seed.getValue());
+        GrayCRandomManager::DeleteInstance(GET_VALUE(Seed));
         return true;
       }
       void AssignmentExpressionMutator::buildExpressionVector(const MatchFinder::MatchResult &Result, llvm::SmallVector<llvm::StringRef, 20> &expressions, const Expr *E)
       {
         if (!isa<BinaryOperator>(E))
         {
-          GrayCRandomManager::DeleteInstance(Seed.getValue());
+          GrayCRandomManager::DeleteInstance(GET_VALUE(Seed));
           return;
         }
         else

--- a/grayc/cmutation/AssignmentExpressionMutator.h
+++ b/grayc/cmutation/AssignmentExpressionMutator.h
@@ -10,6 +10,7 @@
 #define LLVM_CLANG_TOOLS_EXTRA_GRAYC_CMUTATION_ASSIGNMENTEXPRESSIONMUTATOR_H
 
 #include "../GrayCCheck.h"
+#include "../Compatability.h"
 
 namespace clang
 {
@@ -40,7 +41,7 @@ namespace clang
             : GrayCCheck(Name, Context) {Seed = Context->getOptions().Seed;}
         void registerMatchers(ast_matchers::MatchFinder *Finder) override;
         void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
-        llvm::Optional<long> Seed;
+        OPTIONAL(long) Seed;
         // Taken from LLVM source repo
         // [C++ 5.5] Pointer-to-member operators.
         // [C99 6.5.5] Multiplicative operators.

--- a/grayc/cmutation/ConditionalExpressionMutator.cpp
+++ b/grayc/cmutation/ConditionalExpressionMutator.cpp
@@ -25,7 +25,7 @@ void ConditionalExpressionMutator::registerMatchers(MatchFinder *Finder) {
 
 void ConditionalExpressionMutator::check(
     const MatchFinder::MatchResult &Result) {
-  srand(Seed.getValue());
+  srand(GET_VALUE(Seed));
   const SourceManager &SM = *Result.SourceManager;
   const ASTContext *Context = Result.Context;
   llvm::WithColor::remark() << "Using SEED: " << Seed << "\n";
@@ -38,15 +38,15 @@ void ConditionalExpressionMutator::check(
 bool ConditionalExpressionMutator::mutateConditional(
     const MatchFinder::MatchResult &Result, const BinaryOperator *C,
     SourceLocation InitialLoc, SourceLocation EndLocHint) {
-  GrayCRandomManager::CreateInstance(Seed.getValue(), 65000);
+  GrayCRandomManager::CreateInstance(GET_VALUE(Seed), 65000);
   if (GrayCRandomManager::GetInstance()->rnd_yes_no(0.6)) {
     llvm::WithColor::note()
         << "Ignoring potential expression mutation due to the given seed\n";
-    GrayCRandomManager::DeleteInstance(Seed.getValue());
+    GrayCRandomManager::DeleteInstance(GET_VALUE(Seed));
     return true;
   }
   if (!InitialLoc.isValid()){
-    GrayCRandomManager::DeleteInstance(Seed.getValue());
+    GrayCRandomManager::DeleteInstance(GET_VALUE(Seed));
     return false;
   }
   const SourceManager &SM = *Result.SourceManager;
@@ -57,7 +57,7 @@ bool ConditionalExpressionMutator::mutateConditional(
       CharSourceRange::getTokenRange(C->getSourceRange()), SM,
       Context->getLangOpts());
   if (FileRange.isInvalid()){
-    GrayCRandomManager::DeleteInstance(Seed.getValue());
+    GrayCRandomManager::DeleteInstance(GET_VALUE(Seed));
     return false;
   }
   InitialLoc = Lexer::makeFileCharRange(
@@ -66,7 +66,7 @@ bool ConditionalExpressionMutator::mutateConditional(
                    .getBegin();
 
   if (InitialLoc.isInvalid()){
-    GrayCRandomManager::DeleteInstance(Seed.getValue());
+    GrayCRandomManager::DeleteInstance(GET_VALUE(Seed));
     return false;
   }
   assert(EndLocHint.isValid());
@@ -74,7 +74,7 @@ bool ConditionalExpressionMutator::mutateConditional(
   buildExpressionVector(Result, expressions, C);
   if (expressions.size() == 0) {
     llvm::WithColor::remark() << "No subexpressions collected!!";
-    GrayCRandomManager::DeleteInstance(Seed.getValue());
+    GrayCRandomManager::DeleteInstance(GET_VALUE(Seed));
     return false;
   }
   ConditionOperatorKind CK = ConditionOperatorKind(GrayCRandomManager::GetInstance()->rnd_dice(Last));
@@ -94,7 +94,7 @@ bool ConditionalExpressionMutator::mutateConditional(
   Diag << FixItHint::CreateReplacement(
       CharSourceRange::getTokenRange(InitialLoc, EndLocHint),
       MutatedConditional.str());
-  GrayCRandomManager::DeleteInstance(Seed.getValue());
+  GrayCRandomManager::DeleteInstance(GET_VALUE(Seed));
   return true;
 }
 void ConditionalExpressionMutator::buildExpressionVector(

--- a/grayc/cmutation/ConditionalExpressionMutator.h
+++ b/grayc/cmutation/ConditionalExpressionMutator.h
@@ -10,6 +10,7 @@
 #define LLVM_CLANG_TOOLS_EXTRA_GRAYC_CMUTATION_CONDITIONALEXPRESSIONMUTATOR_H
 
 #include "../GrayCCheck.h"
+#include "../Compatability.h"
 
 namespace clang
 {
@@ -27,7 +28,7 @@ namespace clang
             : GrayCCheck(Name, Context) { Seed = Context->getOptions().Seed;}
         void registerMatchers(ast_matchers::MatchFinder *Finder) override;
         void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
-        llvm::Optional<long> Seed;
+        OPTIONAL(long) Seed;
         // Taken from LLVM source repo
         // [C++ 5.5] Pointer-to-member operators.
         // [C99 6.5.5] Multiplicative operators.

--- a/grayc/cmutation/DuplicateStatementMutator.cpp
+++ b/grayc/cmutation/DuplicateStatementMutator.cpp
@@ -30,12 +30,12 @@ void DuplicateStatementMutator::check(const MatchFinder::MatchResult &Result) {
 
   const SourceManager &SM = *Result.SourceManager;
   const ASTContext *Context = Result.Context;
-  GrayCRandomManager::CreateInstance(Seed.getValue(), 65000);
+  GrayCRandomManager::CreateInstance(GET_VALUE(Seed), 65000);
   llvm::WithColor::remark() << "Using SEED: " << Seed << "\n";
   if (GrayCRandomManager::GetInstance()->rnd_yes_no(0.7)) {
     llvm::WithColor::note()
             << "Ignoring potential duplicate statement mutation due to the given seed\n";
-            GrayCRandomManager::DeleteInstance(Seed.getValue());
+            GrayCRandomManager::DeleteInstance(GET_VALUE(Seed));
     return;
   }
   const auto *BinaryOp = Result.Nodes.getNodeAs<BinaryOperator>("binaryOp");
@@ -44,7 +44,7 @@ void DuplicateStatementMutator::check(const MatchFinder::MatchResult &Result) {
       CharSourceRange::getTokenRange(BinaryOp->getSourceRange()), SM,
       Context->getLangOpts());
   if (FileRange.isInvalid()) {
-    GrayCRandomManager::DeleteInstance(Seed.getValue());
+    GrayCRandomManager::DeleteInstance(GET_VALUE(Seed));
     return;
   }
   if (BinaryOp) {
@@ -68,7 +68,7 @@ void DuplicateStatementMutator::check(const MatchFinder::MatchResult &Result) {
                                            DuplicatedStringToInsert);
       
     }
-    GrayCRandomManager::DeleteInstance(Seed.getValue());
+    GrayCRandomManager::DeleteInstance(GET_VALUE(Seed));
   }
 }
 } // namespace cmutation

--- a/grayc/cmutation/DuplicateStatementMutator.h
+++ b/grayc/cmutation/DuplicateStatementMutator.h
@@ -10,6 +10,7 @@
 #define LLVM_CLANG_TOOLS_EXTRA_GRAYC_CMUTATION_DUPLICATESTATEMENTMUTATOR_H
 
 #include "../GrayCCheck.h"
+#include "../Compatability.h"
 
 namespace clang {
 namespace grayc {
@@ -23,7 +24,7 @@ public:
       : GrayCCheck(Name, Context) {Seed = Context->getOptions().Seed;}
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
-  llvm::Optional<long> Seed;
+  OPTIONAL(long) Seed;
 };
 
 } // namespace cmutation

--- a/grayc/cmutation/JumpMutator.cpp
+++ b/grayc/cmutation/JumpMutator.cpp
@@ -54,11 +54,11 @@ namespace clang
           const MatchFinder::MatchResult &Result, LoopKind L, const Stmt *S,
           SourceLocation InitialLoc, SourceLocation EndLocHint)
       {
-        GrayCRandomManager::CreateInstance(Seed.getValue(), 65000);
+        GrayCRandomManager::CreateInstance(GET_VALUE(Seed), 65000);
         if (GrayCRandomManager::GetInstance()->rnd_yes_no(0.4)){
           llvm::WithColor::note()
             << "Ignoring potential jump statement mutation due to the given seed\n";
-          GrayCRandomManager::DeleteInstance(Seed.getValue());
+          GrayCRandomManager::DeleteInstance(GET_VALUE(Seed));
           return true;
         }
         if (!InitialLoc.isValid())

--- a/grayc/cmutation/JumpMutator.h
+++ b/grayc/cmutation/JumpMutator.h
@@ -10,6 +10,7 @@
 #define LLVM_CLANG_TOOLS_EXTRA_GRAYC_CMUTATION_JUMPMUTATOR_H
 
 #include "../GrayCCheck.h"
+#include "../Compatability.h"
 
 namespace clang
 {
@@ -27,7 +28,7 @@ namespace clang
             : GrayCCheck(Name, Context) {Seed = Context->getOptions().Seed;}
         void registerMatchers(ast_matchers::MatchFinder *Finder) override;
         void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
-        llvm::Optional<long> Seed;
+        OPTIONAL(long) Seed;
       private:
         enum LoopKind {For,While,DoWhile};
         bool mutateLoop(const ast_matchers::MatchFinder::MatchResult &Result,LoopKind L, 

--- a/grayc/cmutation/UnaryOperatorCheck.cpp
+++ b/grayc/cmutation/UnaryOperatorCheck.cpp
@@ -130,11 +130,11 @@ void UnaryOperatorCheck::check(const MatchFinder::MatchResult &Result) {
 bool UnaryOperatorCheck::mutateUnaryOperator(
     const MatchFinder::MatchResult &Result, const UnaryOperator *S,
     SourceLocation InitialLoc, SourceLocation EndLocHint) {
-  GrayCRandomManager::CreateInstance(Seed.getValue(), 65000);
+  GrayCRandomManager::CreateInstance(GET_VALUE(Seed), 65000);
   if (GrayCRandomManager::GetInstance()->rnd_yes_no(0.6)) {
     llvm::WithColor::note()
         << "Ignoring potential unary operator mutation due to the given seed\n";
-    GrayCRandomManager::DeleteInstance(Seed.getValue());
+    GrayCRandomManager::DeleteInstance(GET_VALUE(Seed));
     return true;
   }
   if (!S->isIncrementOp() && !S->isDecrementOp()) {
@@ -167,7 +167,7 @@ bool UnaryOperatorCheck::mutateUnaryOperator(
   Diag << FixItHint::CreateReplacement(
       CharSourceRange::getTokenRange(InitialLoc, EndLocHint), MutatedOperator);
 
-  GrayCRandomManager::DeleteInstance(Seed.getValue());
+  GrayCRandomManager::DeleteInstance(GET_VALUE(Seed));
   return true;
 }
 

--- a/grayc/cmutation/UnaryOperatorCheck.h
+++ b/grayc/cmutation/UnaryOperatorCheck.h
@@ -10,6 +10,7 @@
 #define GRAYC_READABILITY_UnaryOperatorCheck_H
 
 #include "../GrayCCheck.h"
+#include "../Compatability.h"
 
 namespace clang {
 namespace grayc {
@@ -35,7 +36,7 @@ public:
   UnaryOperatorCheck(StringRef Name, GrayCContext *Context) : GrayCCheck(Name, Context) {Seed = Context->getOptions().Seed;}
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
-  llvm::Optional<long> Seed;
+  OPTIONAL(long) Seed;
 private:
   bool mutateUnaryOperator(const ast_matchers::MatchFinder::MatchResult &Result,
                  const UnaryOperator *S, SourceLocation StartLoc,

--- a/grayc/tool/CMakeLists.txt
+++ b/grayc/tool/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.13.4)
 project(grayc-st)
 
 #===============================================================================

--- a/grayc/utils/FixItHintUtils.h
+++ b/grayc/utils/FixItHintUtils.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_CLANG_TOOLS_EXTRA_GRAYC_UTILS_FIXITHINTUTILS_H
 #define LLVM_CLANG_TOOLS_EXTRA_GRAYC_UTILS_FIXITHINTUTILS_H
 
+#include "../Compatability.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
 #include "clang/Sema/DeclSpec.h"
@@ -41,7 +42,7 @@ enum class QualifierTarget {
 
 /// \brief Creates fix to qualify ``VarDecl`` with the specified \c Qualifier.
 /// Requires that `Var` is isolated in written code like in `int foo = 42;`.
-Optional<FixItHint>
+OPTIONAL(FixItHint)
 addQualifierToVarDecl(const VarDecl &Var, const ASTContext &Context,
                       DeclSpec::TQ Qualifier,
                       QualifierTarget CT = QualifierTarget::Pointee,

--- a/grayc/utils/LexerUtils.cpp
+++ b/grayc/utils/LexerUtils.cpp
@@ -76,10 +76,10 @@ SourceLocation findNextTerminator(SourceLocation Start, const SourceManager &SM,
   return findNextAnyTokenKind(Start, SM, LangOpts, tok::comma, tok::semi);
 }
 
-Optional<Token> findNextTokenSkippingComments(SourceLocation Start,
+OPTIONAL(Token) findNextTokenSkippingComments(SourceLocation Start,
                                               const SourceManager &SM,
                                               const LangOptions &LangOpts) {
-  Optional<Token> CurrentToken;
+  OPTIONAL(Token) CurrentToken;
   do {
     CurrentToken = Lexer::findNextToken(Start, SM, LangOpts);
   } while (CurrentToken && CurrentToken->is(tok::comment));
@@ -96,7 +96,7 @@ bool rangeContainsExpansionsOrDirectives(SourceRange Range,
     if (Loc.isMacroID())
       return true;
 
-    llvm::Optional<Token> Tok = Lexer::findNextToken(Loc, SM, LangOpts);
+    OPTIONAL(Token) Tok = Lexer::findNextToken(Loc, SM, LangOpts);
 
     if (!Tok)
       return true;
@@ -110,7 +110,7 @@ bool rangeContainsExpansionsOrDirectives(SourceRange Range,
   return false;
 }
 
-llvm::Optional<Token> getQualifyingToken(tok::TokenKind TK,
+OPTIONAL(Token) getQualifyingToken(tok::TokenKind TK,
                                          CharSourceRange Range,
                                          const ASTContext &Context,
                                          const SourceManager &SM) {
@@ -121,8 +121,8 @@ llvm::Optional<Token> getQualifyingToken(tok::TokenKind TK,
   StringRef File = SM.getBufferData(LocInfo.first);
   Lexer RawLexer(SM.getLocForStartOfFile(LocInfo.first), Context.getLangOpts(),
                  File.begin(), File.data() + LocInfo.second, File.end());
-  llvm::Optional<Token> LastMatchBeforeTemplate;
-  llvm::Optional<Token> LastMatchAfterTemplate;
+  OPTIONAL(Token) LastMatchBeforeTemplate;
+  OPTIONAL(Token) LastMatchAfterTemplate;
   bool SawTemplate = false;
   Token Tok;
   while (!RawLexer.LexFromRawLexer(Tok) &&
@@ -137,7 +137,7 @@ llvm::Optional<Token> getQualifyingToken(tok::TokenKind TK,
     if (Tok.is(tok::less))
       SawTemplate = true;
     else if (Tok.isOneOf(tok::greater, tok::greatergreater))
-      LastMatchAfterTemplate = None;
+      LastMatchAfterTemplate = OPTIONAL_NONE;
     else if (Tok.is(TK)) {
       if (SawTemplate)
         LastMatchAfterTemplate = Tok;
@@ -145,7 +145,8 @@ llvm::Optional<Token> getQualifyingToken(tok::TokenKind TK,
         LastMatchBeforeTemplate = Tok;
     }
   }
-  return LastMatchAfterTemplate != None ? LastMatchAfterTemplate
+  // ???
+  return LastMatchAfterTemplate != OPTIONAL_NONE ? LastMatchAfterTemplate
                                         : LastMatchBeforeTemplate;
 }
 } // namespace lexer

--- a/grayc/utils/LexerUtils.h
+++ b/grayc/utils/LexerUtils.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_CLANG_TOOLS_EXTRA_GRAYC_UTILS_LEXER_UTILS_H
 #define LLVM_CLANG_TOOLS_EXTRA_GRAYC_UTILS_LEXER_UTILS_H
 
+#include "../Compatability.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/Basic/TokenKinds.h"
 #include "clang/Lex/Lexer.h"
@@ -64,7 +65,7 @@ SourceLocation findNextAnyTokenKind(SourceLocation Start,
                                     const LangOptions &LangOpts, TokenKind TK,
                                     TokenKinds... TKs) {
   while (true) {
-    Optional<Token> CurrentToken = Lexer::findNextToken(Start, SM, LangOpts);
+    OPTIONAL(Token) CurrentToken = Lexer::findNextToken(Start, SM, LangOpts);
 
     if (!CurrentToken)
       return SourceLocation();
@@ -83,7 +84,7 @@ SourceLocation findNextAnyTokenKind(SourceLocation Start,
 }
 
 // Finds next token that's not a comment.
-Optional<Token> findNextTokenSkippingComments(SourceLocation Start,
+OPTIONAL(Token) findNextTokenSkippingComments(SourceLocation Start,
                                               const SourceManager &SM,
                                               const LangOptions &LangOpts);
 
@@ -99,7 +100,7 @@ bool rangeContainsExpansionsOrDirectives(SourceRange Range,
 /// must be valid with respect to ``SM``.  Returns ``None`` if no qualifying
 /// tokens are found.
 /// \note: doesn't support member function qualifiers.
-llvm::Optional<Token> getQualifyingToken(tok::TokenKind TK,
+OPTIONAL(Token) getQualifyingToken(tok::TokenKind TK,
                                          CharSourceRange Range,
                                          const ASTContext &Context,
                                          const SourceManager &SM);


### PR DESCRIPTION
This pull request introduces compatibility for LLVM 17 , and also updates the CMake version and build setup.

Refactors the codebase to use a compatibility layer for handling differences in Optional types and string comparison APIs. The changes ensure that the code can be built and run against both LLVM 12 and LLVM 17.

**LLVM Version Compatibility and Build System Updates:**

* Updated minimum required CMake version to 3.13.4 in both `grayc/CMakeLists.txt` and `clang-diff/CMakeLists.txt`.
* `GRAYC_OLD_LLVM_API` defined for legacy API handling.
* Updated installation instructions in `README.md` to default to LLVM/Clang 17 instead of 12, including all related package and build commands.

**Compatibility Layer for LLVM API Differences:**

* Added a new `grayc/Compatability.h` header that abstracts differences between LLVM 12 and 17 for `Optional` types and case-insensitive string comparison, providing macros like `OPTIONAL`, `HAS_VALUE`, `OPTIONAL_NONE`, `GET_VALUE`, `GET_VALUE_OR`, and `EQUALS_INSENSITIVE`.
* Refactored codebase to use these macros instead of directly referencing `llvm::Optional` or `std::optional`, and to use the appropriate string comparison function depending on LLVM version – this affects multiple files.
